### PR TITLE
ALCF fixes: tiff_to_zarr.py dynamic pixelsize, init_tiff_to_zarr_globus_flow.py, fix for issue #27

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,11 +4,13 @@ globus:
       root_path: /
       uri: spot832.lbl.gov
       uuid: 44ae904c-ab64-4145-a8f0-7287de38324d
-    
+      name: spot832
+
     data832:
       root_path: /data
       uri: data832.lbl.gov
       uuid: 75b478b2-37af-46df-bfbd-71ed692c6506
+      name: data832
 
     data832_raw:
       root_path: /data/raw
@@ -74,6 +76,7 @@ globus:
       root_path: /global/cfs/cdirs/als/data_mover/8.3.2
       uri: nersc.gov
       uuid: df82346e-9a15-11ea-b3c4-0ae144191ee3
+      name: nersc832
 
     nersc7012:
       root_path: /global/cfs/cdirs/als/gsharing/data_mover/7012
@@ -94,8 +97,8 @@ globus:
 
 prefect:
   deployments:
-    - type_spec: new_file_832
-      uuid: ccf2cb27-d4f8-420b-8115-a5036c69b1da
+  - type_spec: new_file_832
+    uuid: ccf2cb27-d4f8-420b-8115-a5036c69b1da
 
 scicat:
   jobs_api_url: https://dataportal.als.lbl.gov/api/ingest/jobs

--- a/orchestration/_tests/test_globus_flow.py
+++ b/orchestration/_tests/test_globus_flow.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Optional
 from uuid import UUID, uuid4
 import warnings
 
-from globus_compute_sdk.sdk.client import Client
 from prefect.blocks.system import JSON, Secret
 from prefect.testing.utilities import prefect_test_harness
 import pytest
@@ -101,9 +100,9 @@ class MockConfig832():
 
 
 # Mock the Client class to avoid real network calls
-class MockGlobusComputeClient(Client):
+class MockGlobusComputeClient:
     def __init__(self, *args, **kwargs):
-        # Skip initializing the real client
+        # No real initialization, as this is a mock
         pass
 
     def version_check(self):
@@ -111,11 +110,11 @@ class MockGlobusComputeClient(Client):
         pass
 
     def run(self, *args, **kwargs):
-        # Mock run to return a fake task ID
+        # Return a mock task ID
         return "mock_task_id"
 
     def get_task(self, task_id):
-        # Mock getting task to return a successful result
+        # Return a mock task response
         return {
             "pending": False,
             "status": "success",
@@ -123,7 +122,7 @@ class MockGlobusComputeClient(Client):
         }
 
     def get_result(self, task_id):
-        # Mock getting the result of a task
+        # Return a mock result
         return "mock_result"
 
 

--- a/orchestration/flows/bl832/move.py
+++ b/orchestration/flows/bl832/move.py
@@ -76,7 +76,10 @@ def transfer_data_to_nersc(
 
 
 @flow(name="new_832_file_flow")
-def process_new_832_file(file_path: str, is_export_control=False, send_to_nersc=True):
+def process_new_832_file(file_path: str,
+                         is_export_control=False,
+                         send_to_nersc=True,
+                         config=None):
     """
     Sends a file along a path:
         - Copy from spot832 to data832
@@ -96,7 +99,8 @@ def process_new_832_file(file_path: str, is_export_control=False, send_to_nersc=
 
     logger = get_run_logger()
     logger.info("starting flow")
-    config = Config832()
+    if not config:
+        config = Config832()
 
     # paths come in from the app on spot832 as /global/raw/...
     # remove 'global' so that all paths start with 'raw', which is common

--- a/orchestration/flows/bl832/prune.py
+++ b/orchestration/flows/bl832/prune.py
@@ -51,7 +51,7 @@ def prune_spot832(relative_path: str):
 def prune_data832(relative_path: str):
     prune_files(relative_path=relative_path,
                 source_endpoint=Config832().data832,
-                check_endpoint=Config832.nersc832)
+                check_endpoint=Config832().nersc832)
 
 
 @flow(name="prune_data832_raw")

--- a/scripts/check_globus_compute.py
+++ b/scripts/check_globus_compute.py
@@ -66,7 +66,7 @@ def main(endpoint_id: str) -> None:
     Check the status of a Globus Compute endpoint by providing the endpoint_id.
 
     Example usage:
-    python check_globus_compute.py --endpoint-id "your-uuid-here"
+    python check_globus_compute.py "your-uuid-here"
 
     IMPORTANT:
     Ensure you are logged into Globus Compute and have set the environment variables for the client credentials:

--- a/scripts/polaris/tiff_to_zarr.py
+++ b/scripts/polaris/tiff_to_zarr.py
@@ -62,7 +62,6 @@ def main():
     if not zarr_dir:
         last_part = os.path.basename(os.path.normpath(tiff_dir))
         zarr_dir = os.path.abspath(os.path.join(tiff_dir, '..', last_part + '.zarr'))
-        # zarr_dir = os.path.abspath(os.path.join(tiff_dir, '..', os.path.basename(tiff_dir) + '.zarr'))
     if not os.path.exists(zarr_dir):
         os.makedirs(zarr_dir)
 
@@ -72,7 +71,6 @@ def main():
     backend = detect_cli_io_backend(file_paths)
     image = cli_input_to_ngff_image(backend, file_paths)
     # The scale and axis units are the same as the one printed in the reconstruction script
-    # image.scale = {'z': 0.65, 'y': 0.65, 'x': 0.65}
     image.scale = read_pixelsize_from_hdf5(args.raw_directory)
     image.axes_units = {'x': 'micrometer', 'y': 'micrometer', 'z': 'micrometer'}
     multiscales = to_multiscales(image, method=Methods.DASK_IMAGE_GAUSSIAN, cache=False)

--- a/scripts/polaris/tiff_to_zarr.py
+++ b/scripts/polaris/tiff_to_zarr.py
@@ -20,10 +20,10 @@ def parse_arguments():
                         type=str,
                         default=None,
                         help='Directory to store Zarr output. Default is new folder in input directory.')
-    parser.add_argument('--raw_directory',
+    parser.add_argument('--raw_file',
                         type=str,
                         default=None,
-                        help='Directory containing the raw hdf5 file (for reading pixelsize metadata).')
+                        help='Path to the raw hdf5 file (for reading pixelsize metadata).')
 
     return parser.parse_args()
 
@@ -37,8 +37,8 @@ def set_permissions_recursive(path, permissions=0o2775):
     os.chmod(path, permissions)  # Also set permissions for the top-level directory
 
 
-def read_pixelsize_from_hdf5(raw_directory: str) -> dict:
-    pxsize = dxchange.read_hdf5(raw_directory,
+def read_pixelsize_from_hdf5(raw_file: str) -> dict:
+    pxsize = dxchange.read_hdf5(raw_file,
                                 "/measurement/instrument/detector/pixel_size")[0]  # Expect mm
     pxsize = pxsize * 1000  # Convert to micrometer
     return {'x': pxsize, 'y': pxsize, 'z': pxsize}
@@ -71,7 +71,7 @@ def main():
     backend = detect_cli_io_backend(file_paths)
     image = cli_input_to_ngff_image(backend, file_paths)
     # The scale and axis units are the same as the one printed in the reconstruction script
-    image.scale = read_pixelsize_from_hdf5(args.raw_directory)
+    image.scale = read_pixelsize_from_hdf5(args.raw_file)
     image.axes_units = {'x': 'micrometer', 'y': 'micrometer', 'z': 'micrometer'}
     multiscales = to_multiscales(image, method=Methods.DASK_IMAGE_GAUSSIAN, cache=False)
     to_ngff_zarr(zarr_dir, multiscales)


### PR DESCRIPTION
- Updated `tiff_to_zarr.py` to read pixelsize from the raw h5 file and convert to micrometer for the multiscales step.
- Updated `init_tiff_to_zarr_globus_flow.py` to account for the new change (passing in the h5 path to the flow) as well as automatically updating the Prefect Secret Block on the server with the latest `flow_id` and `func_id` once the script runs. Side note: I removed the time import from the function definition because I was getting a cryptic "`time.run()` is not defined error" despite only calling `time.time()`.
- Updated instructions for running `check_globus_compute.py` in the docstring.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208451498137898