### PR TITLE
Issue 42 (Dispatcher Enhancements) and Migrate ALCF Allocation to IRI-ALS-832

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,15 +25,15 @@ globus:
       name: data832_scratch
 
     alcf832_raw:
-      root_path: /bl832/raw
+      root_path: /data/raw
       uri: alcf.anl.gov
-      uuid: 55c3adf6-31f1-4647-9a38-52591642f7e7
+      uuid: a89365da-e614-48fe-9ee5-f5e1698a68c8 # 55c3adf6-31f1-4647-9a38-52591642f7e7
       name: alcf_raw
 
     alcf832_scratch:
-      root_path: /bl832/scratch
+      root_path: /data/scratch
       uri: alcf.anl.gov
-      uuid: 55c3adf6-31f1-4647-9a38-52591642f7e7
+      uuid: a89365da-e614-48fe-9ee5-f5e1698a68c8 # 55c3adf6-31f1-4647-9a38-52591642f7e7
       name: alcf_scratch
 
     alcf_eagle832:
@@ -102,6 +102,3 @@ prefect:
 
 scicat:
   jobs_api_url: https://dataportal.als.lbl.gov/api/ingest/jobs
-
-
-

--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -13,21 +13,19 @@ class FlowParameterMapper:
     flow_parameters = {
         # From alcf.py
         "alcf_recon_flow/alcf_recon_flow": [
-            "folder_name",
-            "file_name",
+            "file_path",
             "is_export_control",
-            "send_to_alcf"],
+            "config"],
         # From move.py
         "new_832_file_flow/new_file_832": [
             "file_path",
             "is_export_control",
-            "send_to_nersc",
             "config"],
         # Placeholder parameters for NERSC reconstruction
         "nersc_recon/nersc_recon": [
             "file_path",
-            "config",
-            "send_to_nersc"]  # Placeholder parameters for NERSC reconstruction
+            "is_export_control",
+            "config"]  # Placeholder parameters for NERSC reconstruction
     }
 
     @classmethod
@@ -53,11 +51,7 @@ class DecisionFlowInputModel(BaseModel):
     """
     file_path: Optional[str] = Field(default=None)
     is_export_control: Optional[bool] = Field(default=False)
-    send_to_nersc: Optional[bool] = Field(default=False)
     config: Optional[Union[dict, Any]] = Field(default_factory=dict)
-    send_to_alcf: Optional[bool] = Field(default=False)
-    folder_name: Optional[str] = Field(default=None)
-    file_name: Optional[str] = Field(default=None)
 
 
 @task(name="setup_decision_settings")
@@ -111,11 +105,7 @@ async def run_specific_flow(flow_name: str, parameters: dict) -> None:
 async def dispatcher(
     file_path: Optional[str] = None,
     is_export_control: bool = False,
-    send_to_nersc: bool = False,
     config: Optional[Union[dict, Any]] = None,
-    send_to_alcf: bool = False,
-    folder_name: Optional[str] = None,
-    file_name: Optional[str] = None
 ) -> None:
     """
     Dispatcher flow that reads decision settings and launches tasks accordingly.
@@ -125,11 +115,7 @@ async def dispatcher(
         inputs = DecisionFlowInputModel(
             file_path=file_path,
             is_export_control=is_export_control,
-            send_to_nersc=send_to_nersc,
             config=config,
-            send_to_alcf=send_to_alcf,
-            folder_name=folder_name,
-            file_name=file_name
         )
     except ValidationError as e:
         logger.error(f"Invalid input parameters: {e}")


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/als-computing/splash_flows_globus/issues/42
To summarize:
- Cleanup parameters passed to ALCF flow (file name and folder name --> path) to match those in new_file_832
- Remove send_to_nersc and send_to_alcf from 'dispatcher.py'. Now only `is_export_control` should decide whether to transfer anywhere
- Updated `orchestration/_tests/test_globus_flows.py` to reflect these changes.
- Note: We will need to update the 832 file watcher that kicks off `dispatcher.py` to accept just file_path, and remove file_name and folder_name from being passed in.

Additionally, in this PR, I am migrating our ALCF allocation from IRIBeta to IRI-ALS-832.