### PR TITLE
Issue 53: Build MkDocs GitHub Action

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,4 +33,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
- 
+    - name: Build MkDocs site
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: mkdocs gh-deploy -f docs/mkdocs/mkdocs.yml


### PR DESCRIPTION
Updating GitHub Actions to deploy MkDocs automatically whenever there is a push to main (i.e. it should not rebuild when working on a PR, only when it is merged into main).