### PR TITLE
Issue 53: Update site_url

### DIFF
--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Splash Flows Globus Documentation
 site_description: Splash Flows Globus Documentation
 site_author: ALS Computing
 site_dir: public
-site_url: "https://davramov.github.io/splash_flows_globus/"
+site_url: "https://als-computing.github.io/splash_flows_globus/"
 repo_name: splash_flows_globus
 repo_url: https://github.com/als-computing/splash_flows_globus
 edit_uri: blob/main/docs/


### PR DESCRIPTION
I forgot to change the MkDocs site_url to point toward `als-computing.github.io`, so the github page was not properly deployed.