### PR TITLE
Issue 53: Add "--force" to MkDocs deploy command

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,4 +35,4 @@ jobs:
         pytest
     - name: Build MkDocs site
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: mkdocs gh-deploy -f docs/mkdocs/mkdocs.yml
+      run: mkdocs gh-deploy -f docs/mkdocs/mkdocs.yml --force


### PR DESCRIPTION
In order for the `mkdocs gh-deploy` to run after the initial time, it must have the `--force` command enabled to overwrite the `gh-pages` branch. Merging this change should properly render the documentation now...