### PR TITLE
Issue 58: 7.0.1.1 COSMIC Scattering Flows

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,48 @@
 globus:
   globus_endpoints:
+
+    # 7.0.1.1 ENDPOINTS
+
+    nersc7011_alsdev:
+      root_path: /global/cfs/cdirs/als/data_mover/7.0.1.1/
+      uri: nersc.gov
+      uuid: d40248e6-d874-4f7b-badd-2c06c16f1a58
+      name: nersc7011_alsdev
+
+    nersc7011_alsdev_raw:
+      root_path: /global/cfs/cdirs/als/data_mover/7.0.1.1/raw
+      uri: nersc.gov
+      uuid: d40248e6-d874-4f7b-badd-2c06c16f1a58
+      name: nersc7011_alsdev_raw
+
+    data7011:
+      root_path: /
+      uri: data7011.lbl.gov
+      uuid: tbd
+      name: data7011
+
+    data7011_raw:
+      root_path: /data/raw
+      uri: data7011.lbl.gov
+      uuid: tbd
+      name: data7011_raw
+
+    # 7.0.1.2 ENDPOINTS
+
+    nersc7012:
+      root_path: /global/cfs/cdirs/als/gsharing/data_mover/7012
+      uri: nersc.gov
+      uuid: df82346e-9a15-11ea-b3c4-0ae144191ee3
+      name: nersc7012
+
+    data7012:
+      root_path: /
+      uri: hpc.lbl.gov
+      uuid: 639c49be-604f-423c-9c5d-82a53afe1bf1
+      name: data7012
+
+    # 8.3.2 ENDPOINTS
+
     spot832:
       root_path: /
       uri: spot832.lbl.gov
@@ -89,18 +132,6 @@ globus:
       uri: nersc.gov
       uuid: df82346e-9a15-11ea-b3c4-0ae144191ee3
       name: nersc832
-
-    nersc7012:
-      root_path: /global/cfs/cdirs/als/gsharing/data_mover/7012
-      uri: nersc.gov
-      uuid: df82346e-9a15-11ea-b3c4-0ae144191ee3
-      name: nersc7012
-
-    data7012:
-      root_path: /
-      uri: hpc.lbl.gov
-      uuid: 639c49be-604f-423c-9c5d-82a53afe1bf1
-      name: data7012
 
   globus_apps:
     als_transfer:

--- a/orchestration/_tests/test_globus_flow.py
+++ b/orchestration/_tests/test_globus_flow.py
@@ -51,6 +51,117 @@ class MockEndpoint:
         self.uri = f"mock_endpoint_uri_{self.uuid}"
 
 
+# Mock the Client class to avoid real network calls
+class MockGlobusComputeClient:
+    def __init__(self, *args, **kwargs):
+        # No real initialization, as this is a mock
+        pass
+
+    def version_check(self):
+        # Mock version check to do nothing
+        pass
+
+    def run(self, *args, **kwargs):
+        # Return a mock task ID
+        return "mock_task_id"
+
+    def get_task(self, task_id):
+        # Return a mock task response
+        return {
+            "pending": False,
+            "status": "success",
+            "result": "mock_result"
+        }
+
+    def get_result(self, task_id):
+        # Return a mock result
+        return "mock_result"
+
+
+class MockSecret:
+    value = str(uuid4())
+
+
+# ----------------------------
+# Tests for 7011
+# ----------------------------
+
+class MockConfig7011:
+    def __init__(self) -> None:
+        """
+        Dummy configuration for 7011 flows.
+        """
+        # Create mock endpoints
+        self.endpoints = {
+            "data7011_raw": MockEndpoint(root_path="mock_data7011_raw_path", uuid_value=str(uuid4())),
+            "nersc7011_alsdev_raw": MockEndpoint(root_path="mock_nersc7011_alsdev_raw_path", uuid_value=str(uuid4())),
+        }
+
+        # Define mock apps
+        self.apps = {
+            "als_transfer": "mock_als_transfer_app"
+        }
+
+        # Use the mock transfer client instead of the real TransferClient
+        self.tc = MockTransferClient()
+
+        # Set attributes for easy access
+        self.data7011_raw = self.endpoints["data7011_raw"]
+        self.nersc7011_alsdev_raw = self.endpoints["nersc7011_alsdev_raw"]
+
+
+def test_process_new_7011_file(mocker: MockFixture) -> None:
+    """
+    Test the process_new_7011_file flow from orchestration.flows.bl7011.move.
+
+    This test verifies that:
+      - The get_transfer_controller function is called (patched) with the correct parameters.
+      - The returned transfer controller's copy method is called with the expected file path,
+        source, and destination endpoints from the provided configuration.
+
+    Parameters:
+        mocker (MockFixture): The pytest-mock fixture for patching and mocking objects.
+    """
+    # Import the flow to test.
+    from orchestration.flows.bl7011.move import process_new_7011_file
+
+    # Patch the Secret.load and init_transfer_client in the configuration context.
+    with mocker.patch('prefect.blocks.system.Secret.load', return_value=MockSecret()):
+        mocker.patch(
+            "orchestration.flows.bl7011.config.transfer.init_transfer_client",
+            return_value=mocker.MagicMock()  # Return a dummy TransferClient
+        )
+        from orchestration.flows.bl7011.config import Config7011
+
+    # Instantiate the dummy configuration.
+    mock_config = Config7011()
+
+    # Generate a test file path.
+    test_file_path = f"/tmp/test_file_{uuid4()}.txt"
+
+    # Create a mock transfer controller with a mocked 'copy' method.
+    mock_transfer_controller = mocker.MagicMock()
+    mock_transfer_controller.copy.return_value = True
+
+    # Patch get_transfer_controller where it is used in process_new_733_file.
+    mocker.patch(
+        "orchestration.flows.bl7011.move.get_transfer_controller",
+        return_value=mock_transfer_controller
+    )
+
+    # Execute the flow with the test file path and dummy configuration.
+    result = process_new_7011_file(file_path=test_file_path, config=mock_config)
+
+    # Verify that the transfer controller's copy method was called exactly once.
+    assert mock_transfer_controller.copy.call_count == 1, "Transfer controller copy method should be called exactly once"
+    assert result is None, "The flow should return None"
+
+
+# ----------------------------
+# Tests for 832
+# ----------------------------
+
+
 class MockConfig832():
     def __init__(self) -> None:
         # Mock configuration
@@ -94,39 +205,10 @@ class MockConfig832():
         self.scicat = config["scicat"]
 
 
-# Mock the Client class to avoid real network calls
-class MockGlobusComputeClient:
-    def __init__(self, *args, **kwargs):
-        # No real initialization, as this is a mock
-        pass
-
-    def version_check(self):
-        # Mock version check to do nothing
-        pass
-
-    def run(self, *args, **kwargs):
-        # Return a mock task ID
-        return "mock_task_id"
-
-    def get_task(self, task_id):
-        # Return a mock task response
-        return {
-            "pending": False,
-            "status": "success",
-            "result": "mock_result"
-        }
-
-    def get_result(self, task_id):
-        # Return a mock result
-        return "mock_result"
-
-
 def test_832_dispatcher(mocker: MockFixture):
     """Test 832 uber decision flow."""
 
     # Mock the Secret block load using a simple manual mock class
-    class MockSecret:
-        value = str(uuid4())
 
     mocker.patch('prefect.blocks.system.Secret.load', return_value=MockSecret())
 
@@ -174,11 +256,7 @@ def test_alcf_recon_flow(mocker: MockFixture):
       Case 4) data832->ALCF transfer fails => raises ValueError("Transfer to ALCF Failed")
     """
 
-    # 1) Patch Secret.load(...) so HPC calls won't blow up from malformed UUID
-    mock_secret = mocker.MagicMock()
-    mock_secret.get.return_value = str(uuid4())
-
-    with mocker.patch('prefect.blocks.system.Secret.load', return_value=mock_secret):
+    with mocker.patch('prefect.blocks.system.Secret.load', return_value=MockSecret()):
         # 2) Patch out the calls in Config832 that do real Globus auth:
         #    a) init_transfer_client(...) used in the constructor
         mocker.patch(

--- a/orchestration/flows/bl7011/config.py
+++ b/orchestration/flows/bl7011/config.py
@@ -1,0 +1,13 @@
+from globus_sdk import TransferClient
+from orchestration.globus import transfer
+
+
+class Config7011:
+    def __init__(self) -> None:
+        config = transfer.get_config()
+        self.endpoints = transfer.build_endpoints(config)
+        self.apps = transfer.build_apps(config)
+        self.tc: TransferClient = transfer.init_transfer_client(self.apps["als_transfer"])
+        self.data7011 = self.endpoints["data7011"]
+        self.data7011_raw = self.endpoints["data7011_raw"]
+        self.nersc7011_alsdev_raw = self.endpoints["nersc7011_alsdev_raw"]

--- a/orchestration/flows/bl7011/move.py
+++ b/orchestration/flows/bl7011/move.py
@@ -1,0 +1,30 @@
+import logging
+from prefect import flow
+
+from orchestration.flows.bl7011.config import Config7011
+from orchestration.transfer_controller import CopyMethod, get_transfer_controller
+
+logger = logging.getLogger(__name__)
+
+
+@flow(name="new_7011_file_flow")
+def process_new_7011_file(
+    file_path: str,
+    config: Config7011
+) -> None:
+    """
+
+    """
+
+    logger.info(f"Processing new 733 file: {file_path}")
+
+    transfer_controller = get_transfer_controller(
+        transfer_type=CopyMethod.GLOBUS,
+        config=Config7011()
+    )
+
+    transfer_controller.copy(
+        file_path=file_path,
+        source=config.data7011_raw,
+        destination=config.nersc7011_alsdev_raw
+    )


### PR DESCRIPTION
Starting this PR for extending our Prefect workflows to BL 7.01.1 COSMIC Scattering

This initial commit is similar to the 7.3.3 PR https://github.com/als-computing/splash_flows_globus/pull/60 and includes:
- a new `orchestration/flows/bl7011` directory,
- a `Config7011()` class,
- a `move.py` script,
- Globus endpoint configs,
- and a pytest case for `move.py`.