### PR TITLE
Issue 59: Transfer Flows between CFS and HPSS

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -107,6 +107,11 @@ globus:
       client_id: ${GLOBUS_CLIENT_ID}
       client_secret: ${GLOBUS_CLIENT_SECRET}
 
+hpss_als_endpoint:
+  root_path: /home/a/alsdata
+  uri: nersc.gov
+  name: hpss_als
+
 harbor_images832:
   recon_image: tomorecon_nersc_mpi_hdf5@sha256:cc098a2cfb6b1632ea872a202c66cb7566908da066fd8f8c123b92fa95c2a43c
   multires_image: tomorecon_nersc_mpi_hdf5@sha256:cc098a2cfb6b1632ea872a202c66cb7566908da066fd8f8c123b92fa95c2a43c

--- a/docs/mkdocs/docs/hpss.md
+++ b/docs/mkdocs/docs/hpss.md
@@ -1,0 +1,179 @@
+# Working with The High Performance Storage System (HPSS) at NERSC
+
+HPSS is the tape-based data storage system we use for long term storage of experimental data at the ALS. Tape storage, while it may seem antiquated, is still a very economical and secure medium for infrequently accessed data as tape does not need to be powered except for reading and writing. This requires certain considerations when working with this system.
+
+In `orchestration/transfer_controller.py` we have included two transfer classes for moving data from CFS to HPSS and vice versa (HPSS to CFS). We are following the [HPSS best practices](https://docs.nersc.gov/filesystems/HPSS-best-practices/) outlined in the NERSC documentation.
+
+HPSS is intended for long-term storage of data that is not frequently accessed, and users should aim for file sizes between 100 GB and 2 TB. Since HPSS is a tape system, we need to ensure storage and retrieval commands are done efficiently, as it is a mechanical process to load in a tape and then scroll to the correct region on the tape.
+
+While there are Globus endpoints for HPSS, the NERSC documentation recommends against it as there are certain conditions (i.e. network disconnection) that are not as robust as their recommended HPSS tools `hsi` and `htar`, which they say is the fastest approach. Together, these tools allow us to work with the HPSS filesystem and carefully bundle our projects into `tar` archives that are built directly on HPSS.
+
+## Working with `hsi`
+
+We use `hsi` for handling individual files on HPSS. [Here is the official NERSC documentation for `hsi`.](https://docs.nersc.gov/filesystems/hsi/)
+
+
+**Login to HPSS using `hsi`**
+
+```
+nersc$ hsi
+```
+
+
+**Common `hsi` commands**
+```
+hsi ls: show the contents of your HPSS home directory
+hsi mkdir [new_dir]: create a remote directory in your home
+hsi put [local_file_name]: Transfer a single file into HPSS with the same name
+hsi put -R [local_directory]: Transfer a directory tree into HPSS, creating sub-dirs when needed
+hsi get [/path/to/hpss_file]: Transfer a single file from HPSS into the local directory without renaming
+hsi rm [/path/to/hpss_file]: Prune a file from HPSS
+hsi rm -r [/path/to/hpss_file]: Prune a directory from HPSS
+hsi rmdir /path/to/my_hpss_dir/: Prune an empty directory
+
+```
+
+**Examples**
+
+Find files that are more than 20 days old and redirects the output to the file temp.txt:
+
+```
+hsi -q "find . -ctime 20" > temp.txt 2>&1
+```
+
+## Working with `htar`
+
+We can use `htar` to efficiently work with groups of files on HPSS. The basic syntax of `htar` is similar to the standard `tar` utility:
+
+```
+htar -{c|K|t|x|X} -f tarfile [directories] [files]
+
+-c : Create
+-K : Verify existing tarfile in HPSS
+-t : List
+-x : Extract
+-X : re-create the index file for an existing archive
+```
+
+You cannot add or append files to an existing htar file. The following examples [can also be found here](https://docs.nersc.gov/filesystems/htar/#htar-usage-examples).
+
+**Create an archive with a directory and file**
+
+```
+nersc$ htar -cvf archive.tar project_directory some_extra_file.json
+```
+**List the contents of a `tar` archive**
+```
+nersc$ htar -tf archive.tar
+HTAR: drwx------  als/als          0 2010-09-24 14:24  project_directory/cool_scan1
+HTAR: -rwx------  als/als    9331200 2010-09-24 14:24  project_directory/cool_scan2
+HTAR: -rwx------  als/als    9331200 2010-09-24 14:24  project_directory/cool_scan3
+HTAR: -rwx------  als/als    9331200 2010-09-24 14:24  project_directory/cool_scan4
+HTAR: -rwx------  als/als     398552 2010-09-24 17:35  some_extra_file.json
+HTAR: HTAR SUCCESSFUL
+
+```
+
+**Extract the entire `htar` file**
+
+```
+htar -xvf archive.tar
+```
+
+**Extract a single file from `htar`**
+
+```
+htar -xvf archive.tar project_directory/cool_scan4
+```
+
+**`-Hnostage` option**
+
+If your `htar` files are >100GB, and you only want to extract one or two small member files, you may find faster retrieval rates by skipping staging the file to the HPSS disk cache with `-Hnostage`.
+
+```
+htar -Hnostage -xvf archive.tar project_directory/cool_scan4
+```
+
+## Transferring Data from CFS to HPSS
+
+NERSC provides a special `xfer` QOS ("Quality of Service") for interacting with HPSS, which we can use with our SFAPI Slurm job scripts.
+
+### Single Files
+
+We can transfer single files over to HPSS using `hsi put` in a Slurm script:
+
+**Example `hsi` transfer job**
+
+```
+#SBATCH --qos=xfer
+#SBATCH -C cron
+#SBATCH --time=12:00:00
+#SBATCH --job-name=my_transfer
+#SBATCH --licenses=SCRATCH
+#SBATCH --mem=20GB
+
+# Archive a user's project folder to HPSS
+hsi put /global/cfs/cdirs/als/data_mover/8.3.2/raw/als_user_project_folder/cool_scan1.h5
+```
+
+Notes:
+- `xfer` jobs specifying -N nodes will be rejected at submission time. By default, `xfer` jobs get 2GB of memory allocated. The memory footprint scales somewhat with the size of the file, so if you're archiving larger files, you'll need to request more memory. You can do this by adding `#SBATCH --mem=XGB` to the above script (where X in the range of 5 - 10 GB is a good starting point for large files).
+- NERSC users are at most allowed 15 concurrent `xfer` sessions, which can be used strategically for parallel transfers and reads.
+
+
+### Multiple Files
+
+NERSC recommends that when serving many files smaller than 100 GB we use `htar` to bundle them together before archiving. Since individual scans within a project may not be this large, we try to archive all of the scans in a project into a single `tar` file. If projects end up being larger than 2 TB, we can create multiple `tar` files.
+
+One great part about `htar` is that it builds the archive directly on `HPSS`, so you do not need to worry about needing the additional storage allocation on the CFS side for the `tar` file.
+
+**Example `xfer` transfer job**
+```
+#SBATCH --qos=xfer
+#SBATCH -C cron
+#SBATCH --time=12:00:00
+#SBATCH --job-name=my_transfer
+#SBATCH --licenses=SCRATCH
+#SBATCH --mem=100GB
+
+# Archive a user's project folder to HPSS
+htar -cvf als_user_project.tar /global/cfs/cdirs/als/data_mover/8.3.2/raw/als_user_project_folder
+```
+
+## Transferring Data from HPSS to CFS
+
+At some point you may want to access data from HPSS. An important thing to consider is whether you need to access single or multiple files.
+
+You could extract an entire `htar` file
+
+```
+htar -xvf als_user_project_folder.tar
+```
+
+Or maybe a single file 
+
+```
+htar -xvf als_user_project_folder.tar cool_scan1.h5
+```
+
+## Prefect Flows for HPSS Transfers
+
+Most of the time we expect transfers to occur from CFS to HPSS on a scheduled basis, after users have completed scanning during their alotted beamtime.
+
+### Transfer to HPSS Implementation
+**`orchestration/transfer_controller.py`: `CFSToHPSSTransferController()`**
+
+Input
+Output
+
+### Transfer to CFS Implementation
+**`orchestration/transfer_controller.py`: `HPSSToCFSTransferController()`**
+
+Input
+Output
+
+## Update SciCat with HPSS file paths
+
+TBD
+
+

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
 - Compute at NERSC: nersc832.md
 - Orchestration: orchestration.md
 - Configuration: configuration.md
+- HPSS Tape Archive Access: hpss.md
 # - Troubleshooting: troubleshooting.md
 - Glossary: glossary.md
 - About: about.md

--- a/orchestration/flows/bl832/job_controller.py
+++ b/orchestration/flows/bl832/job_controller.py
@@ -86,9 +86,10 @@ def get_controller(
             config=config
         )
     elif hpc_type == HPC.NERSC:
+        from orchestration.sfapi import create_sfapi_client
         from orchestration.flows.bl832.nersc import NERSCTomographyHPCController
         return NERSCTomographyHPCController(
-            client=NERSCTomographyHPCController.create_sfapi_client(),
+            client=create_sfapi_client(),
             config=config
         )
     elif hpc_type == HPC.OLCF:

--- a/orchestration/flows/bl832/nersc.py
+++ b/orchestration/flows/bl832/nersc.py
@@ -1,13 +1,13 @@
 import datetime
 from dotenv import load_dotenv
-import json
+# import json
 import logging
-import os
+# import os
 from pathlib import Path
 import re
 import time
 
-from authlib.jose import JsonWebKey
+# from authlib.jose import JsonWebKey
 from prefect import flow
 from prefect.blocks.system import JSON
 from sfapi_client import Client
@@ -38,37 +38,39 @@ class NERSCTomographyHPCController(TomographyHPCController):
         super().__init__(config)
         self.client = client
 
-    @staticmethod
-    def create_sfapi_client() -> Client:
-        """Create and return an NERSC client instance"""
+    # Moved this method to orchestration/sfapi.py:
 
-        # When generating the SFAPI Key in Iris, make sure to select "asldev" as the user!
-        # Otherwise, the key will not have the necessary permissions to access the data.
-        client_id_path = os.getenv("PATH_NERSC_CLIENT_ID")
-        client_secret_path = os.getenv("PATH_NERSC_PRI_KEY")
+    # @staticmethod
+    # def create_sfapi_client() -> Client:
+    #     """Create and return an NERSC client instance"""
 
-        if not client_id_path or not client_secret_path:
-            logger.error("NERSC credentials paths are missing.")
-            raise ValueError("Missing NERSC credentials paths.")
-        if not os.path.isfile(client_id_path) or not os.path.isfile(client_secret_path):
-            logger.error("NERSC credential files are missing.")
-            raise FileNotFoundError("NERSC credential files are missing.")
+    #     # When generating the SFAPI Key in Iris, make sure to select "asldev" as the user!
+    #     # Otherwise, the key will not have the necessary permissions to access the data.
+    #     client_id_path = os.getenv("PATH_NERSC_CLIENT_ID")
+    #     client_secret_path = os.getenv("PATH_NERSC_PRI_KEY")
 
-        client_id = None
-        client_secret = None
-        with open(client_id_path, "r") as f:
-            client_id = f.read()
+    #     if not client_id_path or not client_secret_path:
+    #         logger.error("NERSC credentials paths are missing.")
+    #         raise ValueError("Missing NERSC credentials paths.")
+    #     if not os.path.isfile(client_id_path) or not os.path.isfile(client_secret_path):
+    #         logger.error("NERSC credential files are missing.")
+    #         raise FileNotFoundError("NERSC credential files are missing.")
 
-        with open(client_secret_path, "r") as f:
-            client_secret = JsonWebKey.import_key(json.loads(f.read()))
+    #     client_id = None
+    #     client_secret = None
+    #     with open(client_id_path, "r") as f:
+    #         client_id = f.read()
 
-        try:
-            client = Client(client_id, client_secret)
-            logger.info("NERSC client created successfully.")
-            return client
-        except Exception as e:
-            logger.error(f"Failed to create NERSC client: {e}")
-            raise e
+    #     with open(client_secret_path, "r") as f:
+    #         client_secret = JsonWebKey.import_key(json.loads(f.read()))
+
+    #     try:
+    #         client = Client(client_id, client_secret)
+    #         logger.info("NERSC client created successfully.")
+    #         return client
+    #     except Exception as e:
+    #         logger.error(f"Failed to create NERSC client: {e}")
+    #         raise e
 
     def reconstruct(
         self,

--- a/orchestration/sfapi.py
+++ b/orchestration/sfapi.py
@@ -1,0 +1,46 @@
+from dotenv import load_dotenv
+import json
+import logging
+import os
+
+from authlib.jose import JsonWebKey
+from sfapi_client import Client
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+load_dotenv()
+
+
+def create_sfapi_client(
+    client_id_path: str,
+    client_secret_path: str,
+) -> Client:
+    """Create and return an NERSC client instance"""
+
+    # When generating the SFAPI Key in Iris, make sure to select "asldev" as the user!
+    # Otherwise, the key will not have the necessary permissions to access the data.
+    # client_id_path = os.getenv("PATH_NERSC_CLIENT_ID")
+    # client_secret_path = os.getenv("PATH_NERSC_PRI_KEY")
+
+    if not client_id_path or not client_secret_path:
+        logger.error("NERSC credentials paths are missing.")
+        raise ValueError("Missing NERSC credentials paths.")
+    if not os.path.isfile(client_id_path) or not os.path.isfile(client_secret_path):
+        logger.error("NERSC credential files are missing.")
+        raise FileNotFoundError("NERSC credential files are missing.")
+
+    client_id = None
+    client_secret = None
+    with open(client_id_path, "r") as f:
+        client_id = f.read()
+
+    with open(client_secret_path, "r") as f:
+        client_secret = JsonWebKey.import_key(json.loads(f.read()))
+
+    try:
+        client = Client(client_id, client_secret)
+        logger.info("NERSC client created successfully.")
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create NERSC client: {e}")
+        raise e

--- a/orchestration/transfer_controller.py
+++ b/orchestration/transfer_controller.py
@@ -3,11 +3,17 @@ from dotenv import load_dotenv
 from enum import Enum
 import logging
 import os
+from pathlib import Path
+import re
 import time
 from typing import Generic, TypeVar
 
 import globus_sdk
+from sfapi_client import Client
+from sfapi_client.compute import Machine
 
+
+# We should have a more generic Config class that can be used across beamlines...
 from orchestration.flows.bl832.config import Config832
 from orchestration.globus.transfer import GlobusEndpoint, start_transfer
 
@@ -71,6 +77,21 @@ class FileSystemEndpoint(TransferEndpoint):
         if path_suffix.startswith("/"):
             path_suffix = path_suffix[1:]
         return f"{self.root_path.rstrip('/')}/{path_suffix}"
+
+
+class HPSSEndpoint(TransferEndpoint):
+    """
+    An HPSS endpoint.
+
+    Args:
+        TransferEndpoint: Abstract class for endpoints.
+    """
+    def __init__(
+        self,
+        name: str,
+        root_path: str
+    ) -> None:
+        super().__init__(name, root_path)
 
 
 Endpoint = TypeVar("Endpoint", bound=TransferEndpoint)
@@ -175,7 +196,10 @@ class GlobusTransferController(TransferController[GlobusEndpoint]):
 
 
 class SimpleTransferController(TransferController[FileSystemEndpoint]):
-    def __init__(self, config: Config832) -> None:
+    def __init__(
+        self,
+        config: Config832
+    ) -> None:
         super().__init__(config)
     """
     Use a simple 'cp' command to move data within the same system.
@@ -237,6 +261,216 @@ class SimpleTransferController(TransferController[FileSystemEndpoint]):
             logger.info(f"Transfer process took {elapsed_time:.2f} seconds.")
 
 
+class CFSToHPSSTransferController(TransferController[HPSSEndpoint]):
+    def __init__(
+        self,
+        client: Client,
+        config: Config832
+    ) -> None:
+        super().__init__(config)
+        self.client = client
+    """
+    Use SFAPI, Slurm, hsi, and htar to move data from CFS to HPSS at NERSC.
+
+    This transfer contoller requires the source to be a FileSystemEndpoint on CFS and the destination to be an HPSSEndpoint.
+    If you want to move data from somewhere else to HPSS, you will first need to transfer to CFS using a different controller,
+    and then to HPSS with this one.
+
+    Args:
+        TransferController: Abstract class for transferring data.
+    """
+    def copy(
+        self,
+        file_path: str = "",
+        source: FileSystemEndpoint = None,
+        destination: HPSSEndpoint = None,
+    ) -> bool:
+        """
+        Copy a file from a CFS source endpoint to an HPSS destination endpoint.
+
+        For a single file, the transfer is done using hsi (via hsi put).
+        For a directory, the transfer is performed with htar:
+          - If the directory's total size is less than 2TB, a single tar archive is created.
+          - If the size exceeds 2TB, the files are split into multiple tar archives,
+            each not exceeding the 2TB threshold.
+
+        The data is saved on HPSS in the correct location using the destination's root path.
+
+
+        Args:
+            file_path (str): The path of the file or directory to copy.
+            source (FileSystemEndpoint): The CFS source endpoint.
+            destination (HPSSEndpoint): The HPSS destination endpoint.
+        """
+
+        logger.info("Transferring data from CFS to HPSS")
+        if not file_path or not source or not destination:
+            logger.error("Missing required parameters for CFSToHPSSTransferController.")
+            return False
+
+        path = Path(file_path)
+        folder_name = path.parent.name
+        if not folder_name:
+            folder_name = ""
+
+        file_name = f"{path.stem}"
+
+        logger.info(f"File name: {file_name}")
+        logger.info(f"Folder name: {folder_name}")
+
+        # Construct absolute source path as visible on Perlmutter
+        abs_source_path = source.full_path(file_path)
+        dest_root = destination.root_path
+        job_name_suffix = Path(abs_source_path).name
+
+        logs_path = "/global/cfs/cdirs/als/data_mover/hpss_transfer_logs"
+
+        # IMPORTANT: job script must be deindented to the leftmost column or it will fail immediately
+        # Note: If q=debug, there is no minimum time limit
+        # However, if q=preempt, there is a minimum time limit of 2 hours. Otherwise the job won't run.
+        # The realtime queue  can only be used for select accounts (e.g. ALS)
+        job_script = f"""#!/bin/bash
+#SBATCH -q xfer
+#SBATCH -A als
+#SBATCH -C cron
+#SBATCH --time=12:00:00
+#SBATCH --job-name=transfer_to_HPSS_{job_name_suffix}
+#SBATCH --output={logs_path}/%j.out
+#SBATCH --error={logs_path}/%j.err
+#SBATCH --licenses=SCRATCH
+#SBATCH --mem=100GB
+
+set -euo pipefail
+date
+
+# Define source and destination variables
+SOURCE_PATH="{abs_source_path}"
+DEST_ROOT="{dest_root}"
+FOLDER_NAME=$(basename "$SOURCE_PATH")
+DEST_PATH="${{DEST_ROOT}}/${{FOLDER_NAME}}"
+
+# Create destination directory if it doesn't exist on HPSS
+echo "Checking if HPSS destination directory $DEST_PATH exists."
+if hsi ls "$DEST_PATH" >/dev/null 2>&1; then
+    echo "Destination directory $DEST_PATH already exists."
+else
+    echo "Destination directory $DEST_PATH does not exist. Creating it now."
+    hsi mkdir "$DEST_PATH"
+fi
+
+# Check if source is a file or directory, and run the appropriate transfer command (hsi vs htar)
+
+# Case: Single File
+if [ -f "$SOURCE_PATH" ]; then
+    echo "Single file detected. Transferring via hsi put."
+    FILE_NAME=$(basename "$SOURCE_PATH")
+    hsi put "$SOURCE_PATH" "$DEST_PATH/$FILE_NAME"
+
+# Case: Directory
+elif [ -d "$SOURCE_PATH" ]; then
+    # Check directory size and split into multiple archives if necessary
+
+    echo "Directory detected. Calculating total size..."
+    TOTAL_SIZE=$(du -sb "$SOURCE_PATH" | awk '{{print $1}}')
+    THRESHOLD=2199023255552  # 2 TB in bytes
+    echo "Total size: $TOTAL_SIZE bytes"
+
+    # If directory size is less than 2TB, archive directly with htar
+    if [ "$TOTAL_SIZE" -lt "$THRESHOLD" ]; then
+        echo "Directory size is under 2TB. Archiving with htar."
+        htar -cvf "${{DEST_PATH}}/${{FOLDER_NAME}}.tar" "$SOURCE_PATH"
+
+    # If directory size exceeds 2TB, split the project into multiple archives that are less than 2TB each
+    else
+        echo "Directory size exceeds 2TB. Splitting into multiple archives."
+        FILE_LIST=$(mktemp)
+        find "$SOURCE_PATH" -type f > "$FILE_LIST"
+        chunk=1
+        current_size=0
+        current_files=()
+        while IFS= read -r file; do
+            size=$(stat -c%s "$file")
+            if (( current_size + size > THRESHOLD )); then
+                tar_archive="${{DEST_PATH}}/${{FOLDER_NAME}}_part${{chunk}}.tar"
+                echo "Creating archive $tar_archive with size $current_size bytes"
+                htar -cvf "$tar_archive" "${{current_files[@]}}"
+                current_files=()
+                current_size=0
+                ((chunk++))
+            fi
+            current_files+=("$file")
+            current_size=$(( current_size + size ))
+        done < "$FILE_LIST"
+        if [ ${{#current_files[@]}} -gt 0 ]; then
+            tar_archive="${{DEST_PATH}}/${{FOLDER_NAME}}_part${{chunk}}.tar"
+            echo "Creating final archive $tar_archive with size $current_size bytes"
+            htar -cvf "$tar_archive" "${{current_files[@]}}"
+        fi
+        rm "$FILE_LIST"
+    fi
+else
+    echo "Error: $SOURCE_PATH is neither a file nor a directory."
+    exit 1
+fi
+
+date
+"""
+        try:
+            logger.info("Submitting HPSS transfer job to Perlmutter.")
+            perlmutter = self.client.compute(Machine.perlmutter)
+            job = perlmutter.submit_job(job_script)
+            logger.info(f"Submitted job ID: {job.jobid}")
+
+            try:
+                job.update()
+            except Exception as update_err:
+                logger.warning(f"Initial job update failed, continuing: {update_err}")
+
+            time.sleep(60)
+            logger.info(f"Job {job.jobid} current state: {job.state}")
+
+            job.complete()  # Wait until the job completes
+            logger.info("Reconstruction job completed successfully.")
+            return True
+
+        except Exception as e:
+            logger.info(f"Error during job submission or completion: {e}")
+            match = re.search(r"Job not found:\s*(\d+)", str(e))
+
+            if match:
+                jobid = match.group(1)
+                logger.info(f"Attempting to recover job {jobid}.")
+                try:
+                    job = self.client.perlmutter.job(jobid=jobid)
+                    time.sleep(30)
+                    job.complete()
+                    logger.info("Reconstruction job completed successfully after recovery.")
+                    return True
+                except Exception as recovery_err:
+                    logger.error(f"Failed to recover job {jobid}: {recovery_err}")
+                    return False
+            else:
+                # Unknown error: cannot recover
+                return False
+
+
+class HPSSToCFSTransferController(TransferController[HPSSEndpoint]):
+    def __init__(
+        self,
+        client: Client,
+        config: Config832
+    ) -> None:
+        super().__init__(config)
+    """
+    Use SFAPI to move data between CFS and HPSS at NERSC.
+
+    Args:
+        TransferController: Abstract class for transferring data.
+    """
+
+    pass
+
+
 class CopyMethod(Enum):
     """
     Enum representing different transfer methods.
@@ -244,6 +478,8 @@ class CopyMethod(Enum):
     """
     GLOBUS = "globus"
     SIMPLE = "simple"
+    CFS_TO_HPSS = "cfs_to_hpss"
+    HPSS_TO_CFS = "hpss_to_cfs"
 
 
 def get_transfer_controller(
@@ -264,6 +500,18 @@ def get_transfer_controller(
         return GlobusTransferController(config)
     elif transfer_type == CopyMethod.SIMPLE:
         return SimpleTransferController(config)
+    elif transfer_type == CopyMethod.CFS_TO_HPSS:
+        from orchestration.sfapi import create_sfapi_client
+        return CFSToHPSSTransferController(
+            client=create_sfapi_client(),
+            config=config
+        )
+    elif transfer_type == CopyMethod.HPSS_TO_CFS:
+        from orchestration.sfapi import create_sfapi_client
+        return HPSSToCFSTransferController(
+            client=create_sfapi_client(),
+            config=config
+        )
     else:
         raise ValueError(f"Invalid transfer type: {transfer_type}")
 


### PR DESCRIPTION
I am opening this PR to address issue https://github.com/als-computing/splash_flows_globus/issues/59.

Key components in this initial commit:
- Includes a new transfer controller `CFSToHPSSTransferController()` with logic for handling single files vs directories using `SFAPI`, `Slurm`, `hsi`, and `htar` based on HPSS best practices.
- Moves `create_sfapi_client()` to a new file called `orchestration/sfapi.py`. Now it can be easily accessed by multiple components, including the NERSC tomography workflow
- Includes new documentation in MkDocs for HPSS.
- Added an HPSS endpoint to config.yml that we can use to define the root storage location.
- Updates `orchestration/_tests/test_sfapi_flow.py` to reflect the new location of `create_sfapi_client().`

 
This is still a WIP and requires thorough testing, and there are a few outstanding tasks:
- Add logic to the new `HPSSToCFSTransferController()` class (currently is just a placeholder)
- Incorporate the HPSS transfer into our Prefect Flows.
- We need a strategy for storing the `SFAPI` id/key pair. Our application must make it easy to update these values since they expire fairly quickly.
- Refactor all of the `TransferControllers` to accept a generic `config=Config` rather than `config=Config832`, which will help generalize our codebase as we extend support to additional beamlines.
- Build a new script `orchestration/pruning_controller.py` that centralizes and implements Pruning logic for:
    - HPSS as a minimum for this PR, and then start thinking about:
    - Globus Endpoints
    - Local File System Endpoints
- Store HPSS file paths in SciCat