### PR TITLE
[8.3.2] Fixing pscratch prune path for raw file

### DIFF
--- a/orchestration/flows/bl832/nersc.py
+++ b/orchestration/flows/bl832/nersc.py
@@ -373,7 +373,7 @@ def schedule_pruning(
         file_name = path.name  # includes .h5 extension
         pscratch_relative_path = f"{folder_name}/{file_name}"
 
-        flow_name = f"delete {location}: {Path(pscratch_relative_path).name}"
+        flow_name = f"delete {location}: {file_name}"
         schedule_prefect_flow(
             deployment_name=f"prune_{location}/prune_{location}",
             flow_run_name=flow_name,


### PR DESCRIPTION
Addressing this issue that I found: https://github.com/als-computing/splash_flows/issues/103

Now, after reconstruction is complete, the actual relative path for raw files is passed into `schedule_pruning` rather than the original absolute path.