### PR TITLE
Issue 109: SciCat ingest for multiple files

### DIFF
--- a/orchestration/flows/scicat/ingest.py
+++ b/orchestration/flows/scicat/ingest.py
@@ -1,8 +1,7 @@
-from typing import Optional, Dict, Any
 from pathlib import Path
+from typing import Dict, Any
 
 from prefect import flow, get_run_logger
-
 
 from scicat_beamline import ingest
 
@@ -19,18 +18,20 @@ def scicat_ingest_flow(
     """
     Runs the SciCat ingestion process implemented for the given spec identifier,
     on the given folder or file.
-    Args:
-        dataset_path: Path of the asset to ingest. May be file or directory depending on the spec.
+
+    :param dataset_path: Path or list of Paths of the asset(s) to ingest. May be file or directory depending on the spec.
         If SICAT_INGEST_INTERNAL_BASE_FOLDER or SCICAT_INGEST_BASE_FOLDER is set, this path is
         considered relative to that base folder.
-    These remaining args are optional; if not provided, environment variables will be used.
-        ingester_spec: Spec to ingest with. (or set SCICAT_INGEST_INGESTER_SPEC)
-        owner_username: User doing the ingesting. May be different from the user_name, especially if using a token (or set SCICAT_INGEST_OWNER_USERNAME)
-        scicat_url: Scicat server base url. If not provided, will try localhost default (or set SCICAT_INGEST_URL)
-        scicat_username: Scicat server username (or set SCICAT_INGEST_USERNAME)
-        scicat_password: Scicat server password (or set SCICAT_INGEST_PASSWORD)
-    Returns:
-        Dict containing task results or skip message
+
+    These remaining args are optional; if not provided, environment variables will be used:
+
+    :param ingester_spec: Spec to ingest with. (or set SCICAT_INGEST_INGESTER_SPEC)
+    :param owner_username: User doing the ingesting. May be different from the user_name, especially if using a token
+                        (or set SCICAT_INGEST_OWNER_USERNAME)
+    :param scicat_url: Scicat server base url. If not provided, will try localhost default (or set SCICAT_INGEST_URL)
+    :param scicat_username: Scicat server username (or set SCICAT_INGEST_USERNAME)
+    :param scicat_password: Scicat server password (or set SCICAT_INGEST_PASSWORD)
+    :returns: Dict containing task results or skip message
     """
     # Get the Prefect logger for the current flow run
     prefect_adapter = get_run_logger()


### PR DESCRIPTION
This PR addresses the issue https://github.com/als-computing/splash_flows/issues/109, where we need to sometimes ingest multiple files for a single scan (such as bl733).

Corresponds with this issue in `scicat_beamline`: https://github.com/als-computing/scicat_beamline/issues/31


The main change is extending the dataset_path field in the `scicat_ingest_flow()` function to accept either Path or list[Path]

```python
@flow(name="scicat-ingest-flow")
def scicat_ingest_flow(
    dataset_path: Path | list[Path],
```