### PR TITLE
[bl832] Forge dispatcher for segmentation flows

### DIFF
--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -20,6 +20,9 @@ class FlowParameterMapper:
         "alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow": [
             "file_path",
             "config"],
+        "alcf_forge_recon_multisegment_flow/alcf_forge_recon_multisegment_flow": [
+            "file_path",
+            "config"],
         # From move.py
         "new_832_file_flow/new_file_832": [
             "file_path",
@@ -71,6 +74,7 @@ class DecisionFlowInputModel(BaseModel):
 def setup_decision_settings(
     alcf_recon: bool,
     alcf_forge_recon_segment: bool,
+    alcf_forge_recon_multisegment: bool,
     nersc_recon: bool,
     nersc_petiole_segment: bool,
     nersc_moon_segment: bool,
@@ -81,6 +85,7 @@ def setup_decision_settings(
 
     :param alcf_recon: Boolean indicating whether to run the ALCF reconstruction flow.
     :param alcf_forge_recon_segment: Boolean indicating whether to run the ALCF Forge reconstruction segment flow.
+    :param alcf_forge_recon_multisegment: Boolean indicating whether to run the ALCF Forge reconstruction multisegment flow.
     :param nersc_recon: Boolean indicating whether to run the NERSC reconstruction flow.
     :param nersc_petiole_segment: Boolean indicating whether to run the NERSC petiole segmentation flow.
     :param nersc_moon_segment: Boolean indicating whether to run the NERSC moon segmentation flow.
@@ -91,6 +96,7 @@ def setup_decision_settings(
     try:
         logger.info(f"Setting up decision settings: alcf_recon={alcf_recon}, "
                     f"alcf_forge_recon_segment={alcf_forge_recon_segment}, "
+                    f"alcf_forge_recon_multisegment={alcf_forge_recon_multisegment}, "
                     f"nersc_recon={nersc_recon}, "
                     f"nersc_petiole_segment={nersc_petiole_segment}, "
                     f"nersc_moon_segment={nersc_moon_segment}, "
@@ -99,6 +105,7 @@ def setup_decision_settings(
         settings = {
             "alcf_recon_flow/alcf_recon_flow": alcf_recon,
             "alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow": alcf_forge_recon_segment,
+            "alcf_forge_recon_multisegment_flow/alcf_forge_recon_multisegment_flow": alcf_forge_recon_multisegment,
             "nersc_recon_flow/nersc_recon_flow": nersc_recon,
             "nersc_petiole_segment_flow/nersc_petiole_segment_flow": nersc_petiole_segment,
             "nersc_moon_segment_flow/nersc_moon_segment_flow": nersc_moon_segment,
@@ -182,6 +189,14 @@ async def dispatcher(
         )
         tasks.append(run_recon_flow_async("alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow", alcf_forge_params))
 
+    if decision_settings.get("alcf_forge_recon_multisegment_flow/alcf_forge_recon_multisegment_flow"):
+        alcf_forge_params = FlowParameterMapper.get_flow_parameters(
+            "alcf_forge_recon_multisegment_flow/alcf_forge_recon_multisegment_flow",
+            available_params
+        )
+        tasks.append(run_recon_flow_async("alcf_forge_recon_multisegment_flow/alcf_forge_recon_multisegment_flow",
+                                          alcf_forge_params))
+
     if decision_settings.get("nersc_recon_flow/nersc_recon_flow"):
         nersc_params = FlowParameterMapper.get_flow_parameters("nersc_recon_flow/nersc_recon_flow", available_params)
         tasks.append(run_recon_flow_async("nersc_recon_flow/nersc_recon_flow", nersc_params))
@@ -228,6 +243,7 @@ if __name__ == "__main__":
         setup_decision_settings(
             alcf_recon=True,
             alcf_forge_recon_segment=False,
+            alcf_forge_recon_multisegment=False,
             nersc_recon=True,
             nersc_petiole_segment=False,
             nersc_moon_segment=False,

--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -17,6 +17,9 @@ class FlowParameterMapper:
         "alcf_recon_flow/alcf_recon_flow": [
             "file_path",
             "config"],
+        "alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow": [
+            "file_path",
+            "config"],
         # From move.py
         "new_832_file_flow/new_file_832": [
             "file_path",
@@ -67,6 +70,7 @@ class DecisionFlowInputModel(BaseModel):
 @task(name="setup_decision_settings")
 def setup_decision_settings(
     alcf_recon: bool,
+    alcf_forge_recon_segment: bool,
     nersc_recon: bool,
     nersc_petiole_segment: bool,
     nersc_moon_segment: bool,
@@ -76,6 +80,7 @@ def setup_decision_settings(
     This task is used to define the settings for the decision making process of the BL832 beamline.
 
     :param alcf_recon: Boolean indicating whether to run the ALCF reconstruction flow.
+    :param alcf_forge_recon_segment: Boolean indicating whether to run the ALCF Forge reconstruction segment flow.
     :param nersc_recon: Boolean indicating whether to run the NERSC reconstruction flow.
     :param nersc_petiole_segment: Boolean indicating whether to run the NERSC petiole segmentation flow.
     :param nersc_moon_segment: Boolean indicating whether to run the NERSC moon segmentation flow.
@@ -85,6 +90,7 @@ def setup_decision_settings(
     logger = get_run_logger()
     try:
         logger.info(f"Setting up decision settings: alcf_recon={alcf_recon}, "
+                    f"alcf_forge_recon_segment={alcf_forge_recon_segment}, "
                     f"nersc_recon={nersc_recon}, "
                     f"nersc_petiole_segment={nersc_petiole_segment}, "
                     f"nersc_moon_segment={nersc_moon_segment}, "
@@ -92,6 +98,7 @@ def setup_decision_settings(
         # Define which flows to run based on the input settings
         settings = {
             "alcf_recon_flow/alcf_recon_flow": alcf_recon,
+            "alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow": alcf_forge_recon_segment,
             "nersc_recon_flow/nersc_recon_flow": nersc_recon,
             "nersc_petiole_segment_flow/nersc_petiole_segment_flow": nersc_petiole_segment,
             "nersc_moon_segment_flow/nersc_moon_segment_flow": nersc_moon_segment,
@@ -168,6 +175,13 @@ async def dispatcher(
         alcf_params = FlowParameterMapper.get_flow_parameters("alcf_recon_flow/alcf_recon_flow", available_params)
         tasks.append(run_recon_flow_async("alcf_recon_flow/alcf_recon_flow", alcf_params))
 
+    if decision_settings.get("alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow"):
+        alcf_forge_params = FlowParameterMapper.get_flow_parameters(
+            "alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow",
+            available_params
+        )
+        tasks.append(run_recon_flow_async("alcf_forge_recon_segment_flow/alcf_forge_recon_segment_flow", alcf_forge_params))
+
     if decision_settings.get("nersc_recon_flow/nersc_recon_flow"):
         nersc_params = FlowParameterMapper.get_flow_parameters("nersc_recon_flow/nersc_recon_flow", available_params)
         tasks.append(run_recon_flow_async("nersc_recon_flow/nersc_recon_flow", nersc_params))
@@ -208,8 +222,11 @@ if __name__ == "__main__":
         # Setup decision settings based on input parameters
         setup_decision_settings(
             alcf_recon=True,
+            alcf_forge_recon_segment=False,
             nersc_recon=True,
-            nersc_recon_multinode=True,
+            nersc_petiole_segment=False,
+            nersc_moon_segment=False,
+            nersc_forge_recon_segment=False,
             new_file_832=True
         )
         # Run the main decision flow with the specified parameters

--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -200,6 +200,11 @@ async def dispatcher(
         )
         tasks.append(run_recon_flow_async("nersc_moon_segment_flow/nersc_moon_segment_flow", moon_params))
 
+    if decision_settings.get("nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow"):
+        nersc_forge_recon_segment_params = FlowParameterMapper.get_flow_parameters(
+            "nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow", available_params)
+        tasks.append(run_recon_flow_async(
+            "nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow", nersc_forge_recon_segment_params))
     # Run ALCF and NERSC flows in parallel, if any
     if tasks:
         try:

--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -246,17 +246,6 @@ if __name__ == "__main__":
             nersc_forge_recon_multisegment=False,
             new_file_832=True
         )
-        # Run the main decision flow with the specified parameters
-        # asyncio.run(dispatcher(
-        #     config={},  # PYTEST, ALCF, NERSC
-        #     is_export_control=False,  # ALCF & MOVE
-        #     folder_name="folder",  # ALCF
-        #     file_name="file",  # ALCF
-        #     file_path="/path/to/file",  # MOVE
-        #     send_to_alcf=True,  # ALCF
-        #     send_to_nersc=True,  # MOVE
-        #     )
-        # )
     except Exception as e:
         logger = get_run_logger()
         logger.error(f"Failed to execute main flow: {e}")

--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -40,10 +40,6 @@ class FlowParameterMapper:
         "nersc_moon_segment_flow/nersc_moon_segment_flow": [
             "file_path",
             "num_nodes",
-            "config"],
-        "nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow": [
-            "file_path",
-            "num_nodes",
             "config"]
     }
 
@@ -218,18 +214,6 @@ async def dispatcher(
             "nersc_moon_segment_flow/nersc_moon_segment_flow", available_params
         )
         tasks.append(run_recon_flow_async("nersc_moon_segment_flow/nersc_moon_segment_flow", moon_params))
-
-    if decision_settings.get("nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow"):
-        nersc_forge_recon_segment_params = FlowParameterMapper.get_flow_parameters(
-            "nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow", available_params)
-        tasks.append(run_recon_flow_async(
-            "nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow", nersc_forge_recon_segment_params))
-
-    if decision_settings.get("nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow"):
-        nersc_forge_recon_multisegment_params = FlowParameterMapper.get_flow_parameters(
-            "nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow", available_params)
-        tasks.append(run_recon_flow_async(
-            "nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow", nersc_forge_recon_multisegment_params))
 
     # Run ALCF and NERSC flows in parallel, if any
     if tasks:

--- a/orchestration/flows/bl832/dispatcher.py
+++ b/orchestration/flows/bl832/dispatcher.py
@@ -40,6 +40,10 @@ class FlowParameterMapper:
         "nersc_moon_segment_flow/nersc_moon_segment_flow": [
             "file_path",
             "num_nodes",
+            "config"],
+        "nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow": [
+            "file_path",
+            "num_nodes",
             "config"]
     }
 
@@ -220,6 +224,13 @@ async def dispatcher(
             "nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow", available_params)
         tasks.append(run_recon_flow_async(
             "nersc_forge_recon_segment_flow/nersc_forge_recon_segment_flow", nersc_forge_recon_segment_params))
+
+    if decision_settings.get("nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow"):
+        nersc_forge_recon_multisegment_params = FlowParameterMapper.get_flow_parameters(
+            "nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow", available_params)
+        tasks.append(run_recon_flow_async(
+            "nersc_forge_recon_multisegment_flow/nersc_forge_recon_multisegment_flow", nersc_forge_recon_multisegment_params))
+
     # Run ALCF and NERSC flows in parallel, if any
     if tasks:
         try:
@@ -248,6 +259,7 @@ if __name__ == "__main__":
             nersc_petiole_segment=False,
             nersc_moon_segment=False,
             nersc_forge_recon_segment=False,
+            nersc_forge_recon_multisegment=False,
             new_file_832=True
         )
         # Run the main decision flow with the specified parameters


### PR DESCRIPTION
This PR updates the bl832 dispatcher.py module to include options for running the recon+segmentation pipelines at ALCF and NERSC.
- Separate from the recon+zarr flows not to disrupt production
- So now there are 4 possible analysis paths
    - NERSC
        - recon+zarr
        - recon+segment 
    - ALCF
        - recon+zarr
        - recon+segment

This PR does not include the new forge flows (https://github.com/als-computing/splash_flows/pull/114 and https://github.com/als-computing/splash_flows/pull/111), but is configured to call them once they are deployed. 