### PR TITLE
Updating Dockerfile to not use requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM prefecthq/prefect:3.4.2-python3.13
 
 WORKDIR /app
-COPY ./requirements.txt /tmp/
-
-RUN pip install -U pip &&        pip install -r /tmp/requirements.txt
 
 COPY . /app/
-RUN pip install -e .
+
+RUN pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir .


### PR DESCRIPTION
Addressing issue https://github.com/als-computing/splash_flows/issues/140. The last merge removed `requirements.txt`, but did not update the Dockerfile.