### PR TITLE
Pin authlib version to 1.6.12 in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "authlib==1.6.12",
+    "cryptography==47.0.0",
     "dynaconf",
+    "fastapi==0.136.1",
     "globus-compute-sdk @ git+https://github.com/globus/globus-compute.git@d1731340074be56861ec91d732bdff44f8e2b46e#subdirectory=compute_sdk",
     "globus-sdk>=3.0",
     "griffe>=0.49.0,<2.0.0",
@@ -25,6 +27,7 @@ dependencies = [
     "pyyaml",
     "scicat_beamline @ git+https://github.com/als-computing/scicat_beamline.git@4828273f5f49ba4eba5442728729e0545b3f5b79",
     "sfapi_client",
+    "starlette==1.0.0",
     "tiled[client]",
     "watchfiles"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "ALS configuration and code for Prefect workflows to move data and
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "authlib",
+    "authlib==1.6.12",
     "dynaconf",
     "globus-compute-sdk @ git+https://github.com/globus/globus-compute.git@d1731340074be56861ec91d732bdff44f8e2b46e#subdirectory=compute_sdk",
     "globus-sdk>=3.0",


### PR DESCRIPTION
Pinning `authlib=1.6.12` as reported in Issue https://github.com/als-computing/splash_flows/issues/144