### PR TITLE
Missing config in globus transfer call

### DIFF
--- a/orchestration/flows/bl832/nersc.py
+++ b/orchestration/flows/bl832/nersc.py
@@ -1894,7 +1894,8 @@ def nersc_recon_flow(
     nersc_to_beegfs_zarr_future = globus_transfer_task.submit(
         file_path=zarr_file_path,
         source=config.nersc832_alsdev_pscratch_scratch,
-        destination=config.beegfs_scratch
+        destination=config.beegfs_scratch,
+        config=config
     )
 
     # Resolve before pruning (which needs to know what landed where)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "authlib==1.6.12",
+    "cryptography==47.0.0",
     "dynaconf",
+    "fastapi==0.136.1",
     "globus-compute-sdk @ git+https://github.com/globus/globus-compute.git@d1731340074be56861ec91d732bdff44f8e2b46e#subdirectory=compute_sdk",
     "globus-sdk>=3.0",
     "griffe>=0.49.0,<2.0.0",
@@ -25,6 +27,7 @@ dependencies = [
     "pyyaml",
     "scicat_beamline @ git+https://github.com/als-computing/scicat_beamline.git@4828273f5f49ba4eba5442728729e0545b3f5b79",
     "sfapi_client",
+    "starlette==1.0.0",
     "tiled[client]",
     "watchfiles"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "ALS configuration and code for Prefect workflows to move data and
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "authlib",
+    "authlib==1.6.12",
     "dynaconf",
     "globus-compute-sdk @ git+https://github.com/globus/globus-compute.git@d1731340074be56861ec91d732bdff44f8e2b46e#subdirectory=compute_sdk",
     "globus-sdk>=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "scicat_beamline @ git+https://github.com/als-computing/scicat_beamline.git@4828273f5f49ba4eba5442728729e0545b3f5b79",
     "sfapi_client",
     "starlette==1.0.0",
-    "tiled[client]",
+    "tiled[all]",
     "watchfiles"
 ]
 


### PR DESCRIPTION
This PR adds a missing config line to this call in `orchestration/flows/bl832/nersc.py`:

```python
    nersc_to_beegfs_zarr_future = globus_transfer_task.submit(
        file_path=zarr_file_path,
        source=config.nersc832_alsdev_pscratch_scratch,
        destination=config.beegfs_scratch,
        config=config
    )
```